### PR TITLE
Prevent errors when "this" is undefined

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-var isProxySupported = isFunction(this.Proxy);
+var isProxySupported = this && isFunction(this.Proxy);
 var defineProperty = Object.defineProperty;
 
 // shim for Function.name for browsers that don't support it. IE, I'm looking at you.


### PR DESCRIPTION
I inject this library in such a way that `this` is undefined (running inside a function) which was preventing me from upgrading the library. This change does a simple check that there is a `this` defined before trying to see if Proxy exists. I realize 99% of cases run this library directly in the global context, but I do not have that option.