### PR TITLE
chore(types): add definition template to Assertion type

### DIFF
--- a/src/object-model.d.ts
+++ b/src/object-model.d.ts
@@ -1,6 +1,6 @@
 import { ExtendObjectDefinition, FromDefinition, FromObjectModelDefinition, ModelDefinition, ObjectModelDefinition } from '../types/definitions';
 
-export type Assertion<D> = (variable: D) => boolean
+export type Assertion<T> = (variable: T) => boolean
 
 export interface ModelError<D> {
 	model: Model<D>
@@ -12,7 +12,7 @@ export interface ModelError<D> {
 
 export interface Model<D> {	
 	definition: D;
-	assertions: Assertion<D>[];
+	assertions: Assertion<this>[];
 	name: string;
 
 	conventionForConstant(variableName: string): boolean;
@@ -26,7 +26,7 @@ export interface Model<D> {
 
 	errorCollector(errors: ModelError<D>[]): void;
 
-	assert(assertion: Assertion<D>, description?: string | Function): this;
+	assert(assertion: Assertion<this>, description?: string | Function): this;
 
 }
 

--- a/src/object-model.d.ts
+++ b/src/object-model.d.ts
@@ -1,6 +1,6 @@
 import { ExtendObjectDefinition, FromDefinition, FromObjectModelDefinition, ModelDefinition, ObjectModelDefinition } from '../types/definitions';
 
-export type Assertion = (variable: unknown) => boolean
+export type Assertion<D> = (variable: D) => boolean
 
 export interface ModelError<D> {
 	model: Model<D>
@@ -12,7 +12,7 @@ export interface ModelError<D> {
 
 export interface Model<D> {	
 	definition: D;
-	assertions: Assertion[];
+	assertions: Assertion<D>[];
 	name: string;
 
 	conventionForConstant(variableName: string): boolean;
@@ -26,7 +26,7 @@ export interface Model<D> {
 
 	errorCollector(errors: ModelError<D>[]): void;
 
-	assert(assertion: Assertion, description?: string | Function): this;
+	assert(assertion: Assertion<D>, description?: string | Function): this;
 
 }
 


### PR DESCRIPTION
I flip-flopped on whether `this` or `D` was better here. Ended up going for `this` because `BasicModel<StringConstructor>` is more accurate than `StringConstructor` when looking at the types in an editor.